### PR TITLE
Configure mail sending with Mandrill

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,7 @@ DEVELOPER_EMAIL=$(git config user.email)
 export RAILS_SECRET_TOKEN=dw19w73upxp02rxrmsy2vbg7o0lmhqepsm4s3zw5iyz0hccs1a9tbflcxhnk19ivdlgdlio4nevbxfi5rlcpkpwx6
 
 export EMAIL_RECIPIENTS=$DEVELOPER_EMAIL
+export MAIL_DELIVERY_METHOD=letter_opener
 
 export AWS_ACCESS_KEY_ID=
 export AWS_SECRET_ACCESS_KEY=
@@ -24,7 +25,7 @@ export STRIPE_PUBLIC_KEY=pk_test_Abcdefghijklm12345
 
 export PGOPTIONS='-c client_min_messages=WARNING'
 
-export APP_HOST=localhost:3000
+export APP_URI=http://localhost:3000
 
 export AIRBRAKE_API_KEY=1234567890abcdef
 

--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem 'authority',                    '~> 2.9.0'     # Authorize user actions in y
 gem 'bootstrap-sass',               '~> 3.0.0.0'     # Twitter Bootstrap front-end framework
 gem 'carrierwave',                  '~> 0.9.0'     # Server side file uploads (hand off from s3_direct_upload)
 gem 'coffee-rails',                 '~> 4.0.0'     # Outside assets for respondes to coffee
-gem 'compass-rails',                '~> 2.0.alpha' # CSS framework
+gem 'compass-rails',                '~> 1.1.2'     # CSS framework
 gem 'dalli',                        '~> 2.6.4'     # Caching with Memcached
 gem 'devise',                       '~> 3.1.1'     # Authentication with Warden
 gem 'fog',                          '~> 1.14.0'    # Ruby cloud services library (used by carrierwave)
@@ -62,7 +62,6 @@ end
 
 group :development, :test do
   gem 'dotenv-rails'          # Autoload ENV vars in .env
-  gem 'letter_opener'         # Open development emails in a browser instead of sending them
   gem 'pry-awesome_print'     # Auto AP in pry
   gem 'pry-rails'             # Interactive REPL debugger
   gem 'pry-plus'              # Add a bunch of awesome pry stuff (rescue, stack_explorer, doc)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -90,8 +90,8 @@ GEM
       chunky_png (~> 1.2)
       fssm (>= 0.2.7)
       sass (~> 3.1)
-    compass-rails (2.0.alpha.0)
-      compass (>= 0.12.2, < 0.14)
+    compass-rails (1.1.2)
+      compass (>= 0.12.2)
     daemons (1.1.9)
     dalli (2.6.4)
     database_cleaner (1.2.0)
@@ -401,7 +401,7 @@ DEPENDENCIES
   capybara_minitest_spec
   carrierwave (~> 0.9.0)
   coffee-rails (~> 4.0.0)
-  compass-rails (~> 2.0.alpha)
+  compass-rails (~> 1.1.2)
   dalli (~> 2.6.4)
   database_cleaner
   devise (~> 3.1.1)

--- a/config/application.rb
+++ b/config/application.rb
@@ -30,6 +30,28 @@ module MyApp
 
     # Raise errors when an unpermitted param is sent to a controller action
     ActiveRecord::Base.send(:include, ActiveModel::ForbiddenAttributesProtection)
+
+    config.app_uri = URI.parse ENV.fetch('APP_URI')
+
+    # ActionMailer Config with Mandrill from Mailchimp for transactional mail
+    config.action_mailer.delivery_method = ENV.fetch('MAIL_DELIVERY_METHOD', :smtp).to_sym
+    if config.action_mailer.delivery_method == :smtp
+      config.action_mailer.smtp_settings = {
+        address:   'smtp.mandrillapp.com',
+        port:      587,
+        enable_starttls_auto: true,
+        user_name: ENV.fetch('MANDRILL_USERNAME'),
+        password:  ENV.fetch('MANDRILL_APIKEY'),
+        authentication: :plain,
+        domain: config.app_uri.host
+      }
+    end
+
+    config.action_mailer.perform_deliveries    = true
+    config.action_mailer.raise_delivery_errors = false
+    config.action_mailer.default charset: "utf-8"
+    config.action_mailer.default_url_options = { protocol: config.app_uri.scheme, host: config.app_uri.host }
+    config.action_mailer.asset_host = config.app_uri.to_s
   end
 end
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -24,8 +24,8 @@ MyApp::Application.configure do
   # Enable serving of images, stylesheets, and JavaScripts from an asset server for mailers.
   config.action_mailer.asset_host = "http://localhost:3000"
 
-  # Don't care if the mailer can't send.
-  config.action_mailer.raise_delivery_errors = false
+  # Raise real errors in development
+  config.action_mailer.raise_delivery_errors = true
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -17,9 +17,7 @@ MyApp::Application.configure do
   config.cache_store = :mem_cache_store, { expires_in: 10.minutes }
 
   # Open email in browser or send via smtp
-  if ENV['EMAIL_RECIPIENTS']
-    config.action_mailer.delivery_method = :smtp
-  else
+  if ENV['EMAIL_RECIPIENTS'] == 'letter_opener'
     config.action_mailer.delivery_method = :letter_opener
   end
 


### PR DESCRIPTION
This is a slight modification of what we ended up with on SoundingBoard.
- Like on SoundingBoard, it avoids using code in development.rb, production.rb, etc., and pulls all environment-specific values from environment variables.

Unlike on SoundingBoard,
- All ENV access uses fetch to fail loudly.
- I combined `APP_HOST` and `APP_PROTOCOL` into a single `APP_URI` environment variable. This is then split into the component parts easily enough.
- There is no development-specific code for setting the mail delivery method. Instead, the method is set using an environment variable.
### Tasks
- [ ] Code review ( @ericboehs and/or @alkrauss48 )
- [ ] Final Review & Merge ( @ericboehs )
