### PR TITLE
Install ENV_BANG, and convert all ENV access to use it

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ gem 'coffee-rails',                 '~> 4.0.0'     # Outside assets for responde
 gem 'compass-rails',                '~> 1.1.2'     # CSS framework
 gem 'dalli',                        '~> 2.6.4'     # Caching with Memcached
 gem 'devise',                       '~> 3.1.1'     # Authentication with Warden
+gem 'env_bang',                     '0.2.2'        # Enforce configuration of environment variables
 gem 'fog',                          '~> 1.14.0'    # Ruby cloud services library (used by carrierwave)
 gem 'font_assets',                  '~> 0.1.10'    # Addresses Access-Control-Allow-Origin asset problems in Firefox
 gem 'has_scope',                    '~> 0.5.1'     # Easy controller scopes

--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ gem 'coffee-rails',                 '~> 4.0.0'     # Outside assets for responde
 gem 'compass-rails',                '~> 1.1.2'     # CSS framework
 gem 'dalli',                        '~> 2.6.4'     # Caching with Memcached
 gem 'devise',                       '~> 3.1.1'     # Authentication with Warden
-gem 'env_bang',                     '0.2.2'        # Enforce configuration of environment variables
+gem 'env_bang-rails',               '0.2.5'        # Enforce configuration of environment variables
 gem 'fog',                          '~> 1.14.0'    # Ruby cloud services library (used by carrierwave)
 gem 'font_assets',                  '~> 0.1.10'    # Addresses Access-Control-Allow-Origin asset problems in Firefox
 gem 'has_scope',                    '~> 0.5.1'     # Easy controller scopes

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -111,7 +111,9 @@ GEM
     dotenv (0.9.0)
     dotenv-rails (0.9.0)
       dotenv (= 0.9.0)
-    env_bang (0.2.2)
+    env_bang (0.2.5)
+    env_bang-rails (0.2.5)
+      env_bang (= 0.2.5)
     erubis (2.7.0)
     eventmachine (1.0.3)
     excon (0.25.3)
@@ -407,7 +409,7 @@ DEPENDENCIES
   database_cleaner
   devise (~> 3.1.1)
   dotenv-rails
-  env_bang (= 0.2.2)
+  env_bang-rails (= 0.2.5)
   factory_girl_rails
   fog (~> 1.14.0)
   font_assets (~> 0.1.10)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -111,6 +111,7 @@ GEM
     dotenv (0.9.0)
     dotenv-rails (0.9.0)
       dotenv (= 0.9.0)
+    env_bang (0.2.2)
     erubis (2.7.0)
     eventmachine (1.0.3)
     excon (0.25.3)
@@ -406,6 +407,7 @@ DEPENDENCIES
   database_cleaner
   devise (~> 3.1.1)
   dotenv-rails
+  env_bang (= 0.2.2)
   factory_girl_rails
   fog (~> 1.14.0)
   font_assets (~> 0.1.10)

--- a/config.ru
+++ b/config.ru
@@ -1,6 +1,6 @@
 # This file is used by Rack-based servers to start the application.
 
 require File.expand_path('config/environment', __dir__)
-use Rack::CanonicalHost, ENV['CANONICAL_HOST'] if ENV['CANONICAL_HOST']
+use Rack::CanonicalHost, ENV!['CANONICAL_HOST'] if ENV!['CANONICAL_HOST']
 
 run Rails.application

--- a/config/application.rb
+++ b/config/application.rb
@@ -6,8 +6,6 @@ require 'rails/all'
 # you've limited to :test, :development, or :production.
 Bundler.require(:default, Rails.env)
 
-require_relative 'env'
-
 module MyApp
   class Application < Rails::Application
     # Settings in config/environments/* take precedence over those specified here.

--- a/config/application.rb
+++ b/config/application.rb
@@ -6,6 +6,8 @@ require 'rails/all'
 # you've limited to :test, :development, or :production.
 Bundler.require(:default, Rails.env)
 
+require_relative 'env'
+
 module MyApp
   class Application < Rails::Application
     # Settings in config/environments/* take precedence over those specified here.
@@ -31,17 +33,17 @@ module MyApp
     # Raise errors when an unpermitted param is sent to a controller action
     ActiveRecord::Base.send(:include, ActiveModel::ForbiddenAttributesProtection)
 
-    config.app_uri = URI.parse ENV.fetch('APP_URI')
+    config.app_uri = URI.parse ENV!['APP_URI']
 
     # ActionMailer Config with Mandrill from Mailchimp for transactional mail
-    config.action_mailer.delivery_method = ENV.fetch('MAIL_DELIVERY_METHOD', :smtp).to_sym
+    config.action_mailer.delivery_method = ENV!['MAIL_DELIVERY_METHOD'].to_sym
     if config.action_mailer.delivery_method == :smtp
       config.action_mailer.smtp_settings = {
         address:   'smtp.mandrillapp.com',
         port:      587,
         enable_starttls_auto: true,
-        user_name: ENV.fetch('MANDRILL_USERNAME'),
-        password:  ENV.fetch('MANDRILL_APIKEY'),
+        user_name: ENV!['MANDRILL_USERNAME'],
+        password:  ENV!['MANDRILL_APIKEY'],
         authentication: :plain,
         domain: config.app_uri.host
       }
@@ -55,4 +57,4 @@ module MyApp
   end
 end
 
-Mail.register_interceptor RecipientInterceptor.new(ENV['EMAIL_RECIPIENTS']) if ENV['EMAIL_RECIPIENTS'] && defined?(Mail) && !Rails.env.test?
+Mail.register_interceptor RecipientInterceptor.new(ENV!['EMAIL_RECIPIENTS']) if ENV!['EMAIL_RECIPIENTS'] && defined?(Mail) && !Rails.env.test?

--- a/config/env.rb
+++ b/config/env.rb
@@ -1,0 +1,25 @@
+ENV!.config do
+  # Force app to redirect to a specified domain
+  use 'CANONICAL_HOST',           default: false
+  use 'APP_URI',                  'E.g. http://localhost:3000'
+
+  use 'MAIL_DELIVERY_METHOD',     default: :smtp, class: Symbol
+  if ENV!['MAIL_DELIVERY_METHOD'] == :smtp
+    use 'MANDRILL_USERNAME',      'Configured automatically by the Mandrill Heroku addon'
+    use 'MANDRILL_APIKEY',        'Configured automatically by the Mandrill Heroku addon'
+  end
+
+  use 'EMAIL_RECIPIENTS',         default: nil
+  use 'BETTER_ERRORS_TRUSTED_IP', default: nil
+
+  use 'RAILS_SECRET_TOKEN', <<-DESC
+To quickly generate a 64-byte token, you can use:
+
+ruby -r 'securerandom' -e 'puts SecureRandom.urlsafe_base64(64)'
+
+And to configure heroku:
+heroku config:add RAILS_SECRET_TOKEN=$(ruby -r 'securerandom' -e 'puts SecureRandom.urlsafe_base64(64)') -r production
+                            DESC
+
+  use 'TURN_FORMAT',              default: false
+end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -16,11 +16,6 @@ MyApp::Application.configure do
   # Cache stuff in memcache
   config.cache_store = :mem_cache_store, { expires_in: 10.minutes }
 
-  # Open email in browser or send via smtp
-  if ENV['EMAIL_RECIPIENTS'] == 'letter_opener'
-    config.action_mailer.delivery_method = :letter_opener
-  end
-
   # Enable serving of images, stylesheets, and JavaScripts from an asset server for mailers.
   config.action_mailer.asset_host = "http://localhost:3000"
 
@@ -51,5 +46,5 @@ MyApp::Application.configure do
     Bullet.rails_logger = true
   end
 
-  BetterErrors::Middleware.allow_ip! ENV['BETTER_ERRORS_TRUSTED_IP'] if (IPAddr(ENV['BETTER_ERRORS_TRUSTED_IP']) rescue false)
+  BetterErrors::Middleware.allow_ip! ENV!['BETTER_ERRORS_TRUSTED_IP'] if (IPAddr(ENV!['BETTER_ERRORS_TRUSTED_IP']) rescue false)
 end

--- a/config/initializers/secret_token.rb
+++ b/config/initializers/secret_token.rb
@@ -9,4 +9,4 @@
 
 # Make sure your secret_key_base is kept private
 # if you're sharing your code publicly.
-MyApp::Application.config.secret_key_base = ENV.fetch('RAILS_SECRET_TOKEN')
+MyApp::Application.config.secret_key_base = ENV!['RAILS_SECRET_TOKEN']

--- a/test/support/initializers/turn.rb
+++ b/test/support/initializers/turn.rb
@@ -1,13 +1,13 @@
 # To enable turn formatting, set the TURN_FORMAT variable to one of the following:
 #   pretty, dot, cue, marshal, outline, or progress
 # or set to true (or on, yes, or 1) to use the default turn format
-if ENV['TURN_FORMAT'].to_s !~ /^(|false|0|off|no|pride)$/i
+if ENV!['TURN_FORMAT']
   require 'turn/autorun'
 
-  if ENV['TURN_FORMAT'] =~ /^(on|yes|1|true)$/i
-    ENV['TURN_FORMAT'] = Turn.config.format.to_s
+  if ENV!['TURN_FORMAT'] =~ /^(on|yes|1|true)$/i
+    ENV!['TURN_FORMAT'] = Turn.config.format.to_s
   else
-    Turn.config.format = ENV['TURN_FORMAT'].intern
+    Turn.config.format = ENV!['TURN_FORMAT'].intern
   end
 else
   require 'minitest/pride'


### PR DESCRIPTION
Addresses issue #2 
## Tasks
- [x] Handle `default: false` scenario
- [x] Make ENV! read from ENV in realtime, not stored values.
- [x] Create railtie in env_bang gem to automatically require the env.rb file before application.rb loads.
